### PR TITLE
Fix non-serializable arguments issue in create todo

### DIFF
--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -1,6 +1,5 @@
 import prisma from "@/util/prismaClient";
 import NewTodo from "@/components/NewTodo";
-import { redirect } from "next/navigation";
 import React from "react";
 
 export interface IFormData {
@@ -10,9 +9,7 @@ export interface IFormData {
 export default function NewPage() {
   const handleAddTodo = async (data: IFormData) => {
     "use server";
-    console.log(JSON.stringify(data));
-    // await prisma.todo.create({ data: { task: data.todo } });
-    // redirect("/");
+    await prisma.todo.create({ data: { task: data.todo } });
   };
 
   return <NewTodo addTodo={handleAddTodo} />;

--- a/src/components/NewTodo/NewTodo.tsx
+++ b/src/components/NewTodo/NewTodo.tsx
@@ -2,6 +2,7 @@
 
 import { ZodType, z } from "zod";
 import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormControl } from "@mui/material";
 import Link from "next/link";
@@ -15,6 +16,7 @@ import {
   StyledStack,
   StyledTextField,
 } from "./NewTodo.style";
+import { rhfServerAdapter } from "@/util/misc";
 
 type AddTodo = { addTodo: (data: IFormData) => Promise<void> };
 
@@ -33,6 +35,8 @@ export const NewTodo = ({ addTodo }: AddTodo) => {
     resolver: zodResolver(schema),
   });
 
+  const { push: pushRoute } = useRouter();
+
   return (
     <>
       <HeadingTypography variant="h3">New Todo</HeadingTypography>
@@ -40,8 +44,9 @@ export const NewTodo = ({ addTodo }: AddTodo) => {
         <FormControl
           noValidate
           component="form"
-          onSubmit={handleSubmit(addTodo)}
-          method="post"
+          onSubmit={handleSubmit(
+            rhfServerAdapter(addTodo, { onSuccess: () => pushRoute("/") })
+          )}
         >
           <StyledTextField
             variant="standard"

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,0 +1,15 @@
+function rhfServerAdapter<TFormSchema, TServerFunctionReturn>(
+  serverFunction: (payload: TFormSchema) => Promise<TServerFunctionReturn>,
+  options: {
+    onSuccess?: (data: TServerFunctionReturn) => void;
+    onFail?: (reason: Error) => void;
+    onComplete?: () => void;
+  }
+) {
+  const { onSuccess, onFail, onComplete } = options;
+  return (data: TFormSchema) => {
+    serverFunction(data).then(onSuccess).catch(onFail).finally(onComplete);
+  };
+}
+
+export { rhfServerAdapter };


### PR DESCRIPTION
This PR fixes this issue that occurs when creating a new todo:
![image](https://github.com/humma-irshad/Todoey/assets/25879048/4a37bceb-0ad1-4cfc-8dfa-d50dddb0101f)
